### PR TITLE
Generated test files are not recognized by lein test task

### DIFF
--- a/src/cljx/hooks.clj
+++ b/src/cljx/hooks.clj
@@ -2,14 +2,22 @@
   (:require leiningen.cljx
             [robert.hooke :as hooke]
             [leiningen.core.project :as project]
-            [leiningen.compile :as lcompile]))
+            [leiningen.compile :as lcompile]
+            [leiningen.test :as ltest]))
+
+(def ^:private hooked (promise))
 
 (defn- hook [task & args]
   ; leiningen.jar/jar unmerges all default profiles before calling through to
   ; e.g. leiningen.compile/compile.  No idea why, but cljx needs to find its
   ; dependency vector, which may be in a profile...
-  (leiningen.cljx/cljx (project/merge-profiles (first args) [:default]))
+  (when (not (realized? hooked))
+    (deliver hooked true)
+    (leiningen.cljx/cljx (project/merge-profiles (first args) [:default])))
   (apply task args))
 
 (defn activate []
-  (hooke/add-hook #'lcompile/compile #'hook))
+  (hooke/add-hook #'lcompile/compile #'hook)
+  ;;Also hook test to workaround https://github.com/technomancy/leiningen/issues/1300
+  ;;File generation will happen only once.
+  (hooke/add-hook #'ltest/test #'hook))


### PR DESCRIPTION
The first time test files are generated via `cljx.hooks` Clojure tests are not discovered by `test` task. ClojureScript tests are discovered fine.

So when running `lein do clean, test` (assuming generated tests are in target/) Clojure tests are never executed.
