### PR TITLE
add notes for configuring cljx for use in libraries

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -196,6 +196,16 @@ valid TODOs:
 * Exclusionary annotations, e.g. `#-cljs`
 * "Union" annotations, e.g. `#+(or clj clr)`
 
+
+### Notes on using Cljx in libraries
+
+When including Cljx files in a library intended for use in other projects, in addition to the `:cljx` build-specific notes above, you will need to ensure you have the `:source-paths` setting properly set.  This will ensure that generated files are included in the jar properly:
+
+```clojure
+:source-paths ["src" "target/generated/clj" "target/generated/cljs"]
+```
+
+
 ### Clojure is a hosted language, in all flavours
 
 Cljx does *not* try to hide implementation differences between host platforms.


### PR DESCRIPTION
Hi, after struggling with setting up cljx for use in a library, and finding a comment on the Clojure mailing list regarding this the exact same day (https://groups.google.com/forum/#!topic/clojure/1GYG-tLeMZE), I thought it would be helpful to add some comments specific to using cljx in a library.

I don't have any strong feelings about how this should be structured, but my main concern is that we have more explicit instructions for including cljx in projects meant to be used as libraries (especially if crossovers are deprecated!).  It's not at all obvious and poking around github projects to try and figure out what may or may not be relevant configuration in the project.clj file is frustrating and counter-productive.

I'm not confident I've got everything that is relevant here, but I did find that the one setting I discuss (`:sourcepaths`) was the difference between getting my cljx-generated code to show up in the jar or not.  I'm happy to reformat this, put this in a different section, pull information out of other sections and add to this, etc., I just think that there needs to be something in there that mentions the relevant configuration directives--let me know what form you'd be happiest accepting this documentation in and I'll gladly provide.

Thanks!
