### PR TITLE
Excluding Clojure dep from sjacket - causing lots of 'version range' warnings

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
 
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [org.clojure/core.match "0.2.0"]
-                 [org.clojars.trptcolin/sjacket "0.1.0.6"]
+                 [org.clojars.trptcolin/sjacket "0.1.0.6" :exclusions [org.clojure/clojure]]
                  [com.cemerick/piggieback "0.1.3"]
                  [watchtower "0.1.1"]]
 


### PR DESCRIPTION
Hi Kevin,

This is a real simple pull request to exclude the transitive Clojure dependency from sjacket on the grounds that it causes numerous 'version ranges found' warnings. Unfortunately downstream users can't exclude the dependency from cljx because the dependency is added in as part of the plugin.

Thanks for a great library :)

James

e.g.:

(WARNING!!! version ranges found for:)
([com.keminglabs/cljx "0.4.0"] -> [org.clojars.trptcolin/sjacket "0.1.0.6"] -> [org.clojure/clojure "[1.3.0,)"]
Consider using [com.keminglabs/cljx "0.4.0" :exclusions [org.clojure/clojure]].)
([com.keminglabs/cljx "0.4.0"] -> [org.clojars.trptcolin/sjacket "0.1.0.6"] -> [net.cgrand/regex "1.1.0"] -> [org.clojure/clojure "[1.2.0,)"]
Consider using [com.keminglabs/cljx "0.4.0" :exclusions [org.clojure/clojure]].)
([com.keminglabs/cljx "0.4.0"] -> [org.clojars.trptcolin/sjacket "0.1.0.6"] -> [net.cgrand/parsley "0.9.1"] -> [org.clojure/clojure "[1.2.0,)"]
Consider using [com.keminglabs/cljx "0.4.0" :exclusions [org.clojure/clojure]].)
([com.keminglabs/cljx "0.4.0"] -> [org.clojars.trptcolin/sjacket "0.1.0.6"] -> [net.cgrand/parsley "0.9.1"] -> [net.cgrand/regex "1.1.0"] -> [org.clojure/clojure "[1.2.0,)"]
Consider using [com.keminglabs/cljx "0.4.0" :exclusions [org.clojure/clojure]].)
