### PR TITLE
Add named profiles

### DIFF
--- a/src/cljx/plugin.clj
+++ b/src/cljx/plugin.clj
@@ -1,5 +1,6 @@
 (ns cljx.plugin
-  (:require [clojure.java.io :as io]))
+  (:require [clojure.java.io :as io]
+            [leiningen.core.project :refer [add-profiles set-profiles]]))
 
 (def ^:private cljx-version
   (-> (io/resource "META-INF/leiningen/com.keminglabs/cljx/project.clj")
@@ -11,12 +12,29 @@
         (str "Something went wrong, version of cljx is not a string: "
              cljx-version))
 
+(def profiles
+  {:cljx/inject-dependencies
+   {:dependencies [['com.keminglabs/cljx cljx-version :scope "test"]]}
+   :cljx/inject-nrepl-middleware
+   {:repl-options
+    {:nrepl-middleware
+     '[cljx.repl-middleware/wrap-cljx cemerick.piggieback/wrap-cljs-repl]}}})
+
+(defn add-to-default-profile
+  [project profiles]
+  (vary-meta project update-in [:profiles :default] (fnil into []) profiles))
+
 (defn middleware
   [project]
-  (-> project
-      (update-in [:dependencies]
-                 (fnil into [])
-                 [['com.keminglabs/cljx cljx-version]])
-      (update-in [:repl-options :nrepl-middleware]
-                 (fnil into [])
-                 '[cljx.repl-middleware/wrap-cljx cemerick.piggieback/wrap-cljs-repl])))
+  (if (-> project meta ::middleware-applied) ; guard recursion via set-profiles
+    project
+    (-> project
+        (vary-meta assoc ::middleware-applied true)
+        (add-profiles profiles)
+        (add-to-default-profile [:cljx/inject-dependencies
+                                 :cljx/inject-nrepl-middleware])
+        (set-profiles
+         (into (-> project meta :included-profiles distinct)
+               [:cljx/inject-dependencies
+                :cljx/inject-nrepl-middleware]))
+        (vary-meta dissoc ::middleware-applied))))

--- a/src/cljx/plugin.clj
+++ b/src/cljx/plugin.clj
@@ -13,10 +13,9 @@
              cljx-version))
 
 (def profiles
-  {:cljx/inject-dependencies
-   {:dependencies [['com.keminglabs/cljx cljx-version :scope "test"]]}
-   :cljx/inject-nrepl-middleware
-   {:repl-options
+  {:cljx/inject
+   {:dependencies [['com.keminglabs/cljx cljx-version :scope "test"]]
+    :repl-options
     {:nrepl-middleware
      '[cljx.repl-middleware/wrap-cljx cemerick.piggieback/wrap-cljs-repl]}}})
 
@@ -31,10 +30,7 @@
     (-> project
         (vary-meta assoc ::middleware-applied true)
         (add-profiles profiles)
-        (add-to-default-profile [:cljx/inject-dependencies
-                                 :cljx/inject-nrepl-middleware])
+        (add-to-default-profile [:cljx/inject])
         (set-profiles
-         (into (-> project meta :included-profiles distinct)
-               [:cljx/inject-dependencies
-                :cljx/inject-nrepl-middleware]))
+         (into (-> project meta :included-profiles distinct) [:cljx/inject]))
         (vary-meta dissoc ::middleware-applied))))

--- a/src/cljx/plugin.clj
+++ b/src/cljx/plugin.clj
@@ -13,8 +13,10 @@
              cljx-version))
 
 (def profiles
-  {:cljx/inject
-   {:dependencies [['com.keminglabs/cljx cljx-version :scope "test"]]
+  {:cljx-inject
+   {:dependencies [['com.keminglabs/cljx cljx-version
+                    ;; pom task is broken otherwise in lein 2.4.3 and earlier
+                    :scope "test"]]
     :repl-options
     {:nrepl-middleware
      '[cljx.repl-middleware/wrap-cljx cemerick.piggieback/wrap-cljs-repl]}}})
@@ -30,7 +32,10 @@
     (-> project
         (vary-meta assoc ::middleware-applied true)
         (add-profiles profiles)
-        (add-to-default-profile [:cljx/inject])
-        (set-profiles
-         (into (-> project meta :included-profiles distinct) [:cljx/inject]))
+        (add-to-default-profile [:cljx-inject])
+        (cond->
+         (not (some #{:cljx-inject} (-> project meta :excluded-profiles)))
+         (set-profiles
+          (distinct
+           (into (-> project meta :included-profiles distinct) [:cljx-inject]))))
         (vary-meta dissoc ::middleware-applied))))


### PR DESCRIPTION
A first tab at using named profiles to prevent cljx dependencies leaking into jar.

Seems to work, but not 100% confident about this yet, as I can't
explicitly remove the profiles, eg. via

  lein with-profile -cljx/inject-dependencies deps :tree

I'm not sure how to achieve this yet though.
