### PR TITLE
Add profiles to plugin

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -118,6 +118,29 @@ To automatically run cljx before starting a REPL, cutting a jar, etc., add its h
 A more comprehensive configuration example can be found
 [here](https://github.com/lynaghk/cljx/blob/master/sample.project.clj).
 
+With leiningen 2.4.4, you can also use profiles injected by the cljx plugin.
+
+To use the profiles, add them to your `project.clj`:
+
+```clj
+:profiles {:downstream [:plugins.cljx/mixed-source]
+           :dev [:plugins.cljx/mixed-test]}
+```
+
+The profiles provided are:
+
+`mixed-source`
+: transforms cljx files in `src/cljx` to `target/generated/src/clj[s]`
+
+`mixed-test`
+: transforms cljx files in `test/cljx` to `target/generated/test/clj[s]`
+
+`cljx-only-source`
+: transforms cljx files in `src` to `target/generated/src/clj[s]`
+
+`cljx-only-test`
+: transforms cljx files in `test` to `target/generated/test/clj[s]`
+
 ## Changelog
 
 See `CHANGES.md` at the root of this repo.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.keminglabs/cljx "0.4.0"
+(defproject com.keminglabs/cljx "hd-0.4.1-SNAPSHOT"
   :description "Static Clojure code rewriting"
   :url "http://github.com/lynaghk/cljx"
   :license {:name "BSD"
@@ -22,7 +22,7 @@
              ; needed to use the project as its own plugin. Leiningen :-(
              :self-plugin [:default {:plugins [[com.keminglabs/cljx "0.4.0-SNAPSHOT"]
                                                [com.cemerick/clojurescript.test "0.3.1"]]}]}
-  
+
   :aliases {"cleantest" ["with-profile" "self-plugin" "do" "clean," "cljx" "once," "test"]}
 
   :eval-in :leiningen)

--- a/src/cljx/profiles.clj
+++ b/src/cljx/profiles.clj
@@ -1,0 +1,40 @@
+;;; Profiles for cljx project layouts
+{:cljx-only-source
+ {:cljx {:builds [{:source-paths ["src"]
+                   :output-path "target/generated/src/clj"
+                   :rules :clj}
+                  {:source-paths ["src"]
+                   :output-path "target/generated/src/cljs"
+                   :rules :cljs}]}
+  :source-paths ^:replace ["target/generated/src/clj"]
+  :resource-paths ^:replace ["target/generated/src/cljs"]}
+
+ :cljx-only-test
+ {:cljx {:builds [{:source-paths ["test"]
+                   :output-path "target/generated/test/clj"
+                   :rules :clj}
+                  {:source-paths ["test"]
+                   :output-path "target/generated/test/cljs"
+                   :rules :cljs}]}
+  :source-paths ["target/generated/test/clj"]
+  :resource-paths ["target/generated/test/cljs"]}
+
+ :mixed-source
+ {:cljx {:builds [{:source-paths ["src/cljx/"]
+                   :output-path "target/generated/src/clj"
+                   :rules :clj}
+                  {:source-paths ["src/cljx"]
+                   :output-path "target/generated/src/cljs"
+                   :rules :cljs}]}
+  :source-paths ^:replace ["src/clj" "target/generated/src/clj"]
+  :resource-paths ^:replace ["src/cljs" "target/generated/src/cljs"]}
+
+ :mixed-test
+ {:cljx {:builds [{:source-paths ["test/cljx/"]
+                   :output-path "target/generated/test/clj"
+                   :rules :clj}
+                  {:source-paths ["test/cljx"]
+                   :output-path "target/generated/test/cljs"
+                   :rules :cljs}]}
+  :source-paths ["test/clj" "target/generated/test/clj"]
+  :resource-paths ["test/cljs" "target/generated/test/cljs"]}}


### PR DESCRIPTION
An example of profiles that could be added given the pending :downstream
profile in leiningen.

An example of what a project.clj looks like when using cljx and
cljsbuild plugin profiles is at
https://github.com/hugoduncan/downstream-profile-examples/blob/master/cljx-cljsbuild-example/project.clj

This is a pull request for discussion only - it relies on
https://github.com/technomancy/leiningen/pull/1673 which has yet to be
merged (and still contains bugs).
