### PR TITLE
Move to the canonical sjacket release

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,8 @@
 
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [org.clojure/core.match "0.2.0"]
-                 [org.clojars.trptcolin/sjacket "0.1.0.6"]
+                 [net.cgrand/sjacket "0.1.1"
+                    :exclusions [org.clojure/clojure]]
                  [com.cemerick/piggieback "0.1.3"]
                  [watchtower "0.1.1"]]
 


### PR DESCRIPTION
This also adds the exclusion to avoid version range warnings stemming from sjacket, regex, and parsley.
