### PR TITLE
Update sample.project.clj to mention :auto-clean

### DIFF
--- a/sample.project.clj
+++ b/sample.project.clj
@@ -23,7 +23,9 @@
   :source-paths ["src/cljx"]
   :test-paths ["target/test-classes"]
   :dependencies [[org.clojure/clojure "1.6.0-alpha1"]]
-
+  ;; needs disabling for Cljx. See
+  ;; https://github.com/technomancy/leiningen/blob/master/sample.project.clj#L389-392.
+  :auto-clean false
   :cljx {:builds [{:source-paths ["src/cljx"]
                    :output-path "target/classes"
                    :rules :clj}


### PR DESCRIPTION
Without it projects that release jars (e.g. libraries) will end up with jars without source files. Ouch.
